### PR TITLE
Link to apps.fedoraproject.org instead of admin.fedoraproject.org

### DIFF
--- a/osmium-tool/index.html
+++ b/osmium-tool/index.html
@@ -64,7 +64,7 @@ They are available for several versions:</p>
 backports</a>).
 
 <p>Packages for several Fedora versions
-<a href="https://admin.fedoraproject.org/pkgdb/package/rpms/osmium-tool/">are available</a>.</p>
+<a href="https://apps.fedoraproject.org/packages/osmium-tool/overview">are available</a>.</p>
 
 
 <h2>License</h2>


### PR DESCRIPTION
This is consistent with the libosmium link and is a more user friendly place to link to.