### PR TITLE
Update download links

### DIFF
--- a/libosmium/index.html
+++ b/libosmium/index.html
@@ -38,7 +38,7 @@ For more detailed information look at the <a href="manual.html">manual</a>.</p>
 <h2>Download</h2>
 
 <p>Current and past releases can be downloaded from
-<a href="https://github.com/osmcode/libosmium/releases">Github</a>.</p>
+<a href="https://github.com/osmcode/libosmium/releases">GitHub</a>.</p>
 
 <p>Packages are available for
 <a href="https://packages.debian.org/source/stretch/libosmium">Debian Stretch</a>,

--- a/osmium-tool/index.html
+++ b/osmium-tool/index.html
@@ -55,17 +55,16 @@ They are available for several versions:</p>
 <h2>Download</h2>
 
 <p>Current and past releases can be downloaded from
-<a href="https://github.com/osmcode/osmium-tool/releases">Github</a>.</p>
+<a href="https://github.com/osmcode/osmium-tool/releases">GitHub</a>.</p>
 
 <p>Packages are available for
-<a href="https://packages.debian.org/source/sid/osmium-tool">Debian Sid</a>
-(also available in
-<a href="https://packages.debian.org/source/jessie-backports/osmium-tool">Jessie
-backports</a>).
-
-<p>Packages for several Fedora versions
-<a href="https://apps.fedoraproject.org/packages/osmium-tool/overview">are available</a>.</p>
-
+<a href="https://packages.debian.org/stretch/osmium-tool">Debian Stretch</a>,
+<a href="https://packages.debian.org/sid/osmium-tool">Sid</a>,
+and <a href="https://packages.debian.org/jessie-backports/osmium-tool">Jessie
+backports</a>;
+<a href="http://packages.ubuntu.com/zesty/osmium-tool">Ubuntu Zesty</a>,
+<a href="https://apps.fedoraproject.org/packages/osmium-tool/overview">Fedora</a>,
+and <a href="http://braumeister.org/formula/osmium-tool">Homebrew</a>.</p>
 
 <h2>License</h2>
 


### PR DESCRIPTION
Osmium-Tool is now in the Homebrew repo. This PR formats the downloading block for osmium-tool the same was as it is for libosmium.