### PR TITLE
Fix typo in concepts manual

### DIFF
--- a/_osmium_concepts/02_entites.md
+++ b/_osmium_concepts/02_entites.md
@@ -129,7 +129,7 @@ references* (`NodeRef`).
 
 In Osmium, ways can optionally also have a location for each node reference.
 This will usually be empty but can be filled, for instance using the
-NodeLocationForWays handler (see below). This is very convenient for many use
+NodeLocationsForWays handler (see below). This is very convenient for many use
 cases.
 
 Ways with zero, one or more node references are allowed. In current OSM data


### PR DESCRIPTION
NodeLocationForWays is actually called NodeLocationsForWays.