### PR TITLE
fix unterminated sentence

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -99,11 +99,9 @@ the Osmium Library was also just called "Osmium".</p>
 <p>Yes. There is the <a href="/pyosmium/">PyOsmium</a> Python module (written
 by Sarah Hoffmann). There is also a now unsupported <a
 href="/node-osmium/">Node Osmium</a> NodeJS module for Javascript developers
-(written by Dane Springmeyer and Jochen Topf) and
-
-Not all functionality available from C++ is available through those
-modules and you'll take a performance hit, but they are much easier to use
-for the average programmer.</p>
+(written by Dane Springmeyer and Jochen Topf). Not all functionality available 
+from C++ is available through those modules and you'll take a performance hit, 
+but they are much easier to use for the average programmer.</p>
 
 <p>If you are interested in making Osmium available in other languages, come
 <a href="/contact.html">talk to us</a>.</p>


### PR DESCRIPTION
putting "Not all functionality..." into own paragraph is another option.

currently it is in fact merged, unlike what HTML intend suggests

current state:

![screen02](https://github.com/osmcode/osmcode.github.io/assets/899988/ca727529-4858-42e1-8066-731db65c7004)
