### PR TITLE
wiki appears to not be outdated anymore

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -77,8 +77,7 @@ available for several versions:</p>
 <h2>OSM Wiki</h2>
 
 <p>Some more information about Osmium can be found in the <a
-href="https://wiki.openstreetmap.org/wiki/Osmium">OSM Wiki</a>. But be aware
-that this information is mostly about the "Old" Osmium.</p>
+href="https://wiki.openstreetmap.org/wiki/Osmium">OSM Wiki</a>.</p>
 
 
 <h2>Talks</h2>


### PR DESCRIPTION
see https://wiki.openstreetmap.org/wiki/Osmium and https://wiki.openstreetmap.org/w/index.php?title=Osmium&oldid=2710642 for its current state

when this warning was added page was looking like this: https://wiki.openstreetmap.org/w/index.php?title=Osmium&oldid=967837

that outdated pages were deleted since then (note red links)