### PR TITLE
describe Node-Osmium as not maintained

### DIFF
--- a/node-osmium/index.html
+++ b/node-osmium/index.html
@@ -15,6 +15,8 @@ title: Node-Osmium
 some of the features of the <a href="/libosmium/">Osmium Library</a> from
 Javascript code.</p>
 
+<p>Note that currently this project is not maintained and its repository is archived.</p>
+
 <h2>Code</h2>
 
 <p>The code is available from GitHub: <a href="https://github.com/osmcode/node-osmium">github.com/osmcode/node-osmium</a>.</p>


### PR DESCRIPTION
maybe it would make sense to remove it from main listing at website and https://wiki.openstreetmap.org/wiki/Osmium ?

Update treadmill is going quick in node world, trying to get it working is unlikely to work nowadays.