### PR TITLE
Remove trailing space from opl node search egrep examples

### DIFF
--- a/_opl_file_format/05_examples.md
+++ b/_opl_file_format/05_examples.md
@@ -37,11 +37,11 @@ Count how many objects were created in each hour of the day:
 
 Find all closed ways:
 
-    egrep '^w' data.osm.opl | egrep 'N(n[0-9]+),.*\1 '
+    egrep '^w' data.osm.opl | egrep 'N(n[0-9]+),.*\1'
 
 Find all ways tagged with `area=yes` that are not closed:
 
-    egrep '^w' data.osm.opl | egrep 'area=yes' | egrep -v 'N(n[0-9]+),.*\1 '
+    egrep '^w' data.osm.opl | egrep 'area=yes' | egrep -v 'N(n[0-9]+),.*\1'
 
 Find all users who have created post boxes:
 


### PR DESCRIPTION
A trailing space makes sense for most opl line elements but not for the node list of ways, since that doesn't have a trailing space before the linefeed.

Testing:

    ajtown@dell5000:~/temp$ egrep '^w' rutland-latest.osm.opl | egrep 'N(n[0-9]+),.*\1 ' | wc
          0       0       0

(before change)

    ajtown@dell5000:~/temp$ egrep '^w' rutland-latest.osm.opl | egrep 'N(n[0-9]+),.*\1' | wc
      10151   91359 2394064

(after change)
